### PR TITLE
docs: fix timestamp passed to predicate

### DIFF
--- a/docs/predicate.md
+++ b/docs/predicate.md
@@ -74,13 +74,13 @@ const {
 } = limitOrderPredicateBuilder;
 
 const simplePredicate: LimitOrderPredicateCallData = and(
-    timestampBelow(Math.round(Date.now() / 1000) + 60_000), // a limit order is valid only for 1 minute
+    timestampBelow(Math.round(Date.now() / 1000) + 60), // a limit order is valid only for 1 minute
     nonceEquals(makerAddress, 4) // a limit order is valid until the nonce of makerAddress is equal to 4
 );
 
 const complexPredicate: LimitOrderPredicateCallData = or(
     and(
-        timestampBelow(Math.round(Date.now() / 1000) + 60_000),
+        timestampBelow(Math.round(Date.now() / 1000) + 60),
         nonceEquals(makerAddress, 4),
         gt('10', tokenAddress, balanceOfCallData)
     ),


### PR DESCRIPTION
The timestamp argument passed to the `timestampBelow` method on the `LimitOrderProtocol` is actually expressed as seconds and not milliseconds. It's comparing it against the `block.timestamp` which is expressed as seconds after the Epoch, not milliseconds, which is basically retrieved by `Date.now()`.